### PR TITLE
Improve portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ JAVA_INCLUDES = -Ijava/native/include
 objects = build/BetaGamma.o build/CMIM.o build/CondMI.o build/DISR.o build/ICAP.o build/JMI.o build/MIM.o build/mRMR_D.o build/WeightedCMIM.o build/WeightedCondMI.o build/WeightedDISR.o build/WeightedJMI.o build/WeightedMIM.o
 
 libFSToolbox.so : $(objects)
-	$(LINKER) $(CFLAGS) -shared -o libFSToolbox.so $(objects) -lm -lMIToolbox
+	$(LINKER) $(CFLAGS) -shared -o libFSToolbox.so $(objects) $(LIBS) -lm -lMIToolbox
 
 libFSToolbox.dll : $(objects)
 	$(LINKER) -shared -o libFSToolbox.dll $(objects) $(LIBS) -lm -lMIToolbox


### PR DESCRIPTION
Link MIToolbox library from a sibling directory instead of previously installing it to the system.